### PR TITLE
Update NORG2_URL to intern.dev.nav.no in dev

### DIFF
--- a/nais/nais-dev.yml
+++ b/nais/nais-dev.yml
@@ -76,7 +76,7 @@ spec:
     - name: "AXSYS_URL"
       value: "https://axsys.dev.intern.nav.no"
     - name: "NORG2_URL"
-      value: "https://norg2.dev.intern.nav.no/norg2"
+      value: "https://norg2.intern.dev.nav.no/norg2"
     - name: "STS_WELL_KNOWN_URL"
       value: "https://security-token-service.nais.preprod.local/.well-known/openid-configuration"
   vault:


### PR DESCRIPTION
Denne endringen førte til feilmelding, så lager en PR for å huske at det må følges opp hvis man prøver å oppdatere urlen senere:
`Caused by: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target`
https://nav-it.slack.com/archives/CDYU0Q86L/p1699942367824259?thread_ts=1699939455.874379&cid=CDYU0Q86L