### PR TITLE
Synced name for correlationId

### DIFF
--- a/src/main/kotlin/no/nav/navansatt/mainModule.kt
+++ b/src/main/kotlin/no/nav/navansatt/mainModule.kt
@@ -58,10 +58,10 @@ fun Application.mainModule(
     install(CallLogging) {
         level = Level.INFO
         filter { call -> !call.request.path().matches(Regex(".*/isready|.*/isalive|.*/metrics")) }
-        callIdMdc("X-Correlation-ID")
+        callIdMdc("correlationId")
     }
     install(CallId) {
-        retrieveFromHeader("X-Correlation-ID")
+        retrieveFromHeader("correlationId")
         generate { UUID.randomUUID().toString() }
     }
     install(Locations)


### PR DESCRIPTION
Benytte samme som PSAK og PEN gjør

Eksempel navansatt `x_X-correlation-ID`, https://logs.adeo.no/app/discover#/doc/96e648c0-980a-11e9-830a-e17bbd64b4db/.ds-navlogs-2024.09.30-000555?id=9xDZQpIB-zinkFdpwK06