### PR TITLE
Redusert minimum antall podder i produksjon fra 4 til 2

### DIFF
--- a/nais/nais-prod.yml
+++ b/nais/nais-prod.yml
@@ -9,7 +9,7 @@ spec:
   image: "{{{ image }}}"
   port: 7000
   replicas:
-    min: 4
+    min: 2
     max: 8
   liveness:
     path: "/internal/isalive"


### PR DESCRIPTION
En del redusert last pga mer caching i PSAK, samt at det generelt ikke ser ut til å være nødvendig med 4 - ei heller før PSAK-endringen.

https://console.nav.cloud.nais.io/team/pensjondeployer/prod-fss/app/navansatt/utilization