### PR TITLE
Gi tilgang til pensjon-oracle-revisjon-backend-pen-q1

### DIFF
--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -39,6 +39,9 @@ spec:
         - application: pensjon-oracle-revisjon-backend-pen
           namespace: pensjon-revisjon
           cluster: prod-fss
+        - application: pensjon-oracle-revisjon-backend-pen-q1
+          namespace: pensjon-revisjon
+          cluster: dev-fss
         - application: pensjon-oracle-revisjon-backend-tp
           namespace: pensjon-revisjon
           cluster: prod-fss


### PR DESCRIPTION
Applikasjonen bruker nav.no tenant hos AzureAd. Den får derfor ikke kalt på pre-prod versjonen av Navansatt. Applikasjonen slår opp faktiske Navidentr