### PR TITLE
TPP-260 Tillat kall fra pensjonskalkulator-backend

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -86,6 +86,9 @@ spec:
         - application: pensjon-psak-q5
           namespace: pensjon-q5
           cluster: dev-gcp
+        - application: pensjonskalkulator-backend
+          namespace: pensjonskalkulator
+          cluster: dev-gcp
         - application: etterlatte-behandling
           namespace: etterlatte
           cluster: dev-gcp

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -63,6 +63,9 @@ spec:
         - application: pensjon-psak
           namespace: pensjondeployer
           cluster: prod-gcp
+        - application: pensjonskalkulator-backend
+          namespace: pensjonskalkulator
+          cluster: prod-gcp
         - application: etterlatte-behandling
           namespace: etterlatte
           cluster: prod-gcp


### PR DESCRIPTION
Pensjonskalkulator-backend behøver å hente den ansattes enhets-ID som input til pensjonsbrev.